### PR TITLE
Central error handling back end

### DIFF
--- a/client/src/viewmodel/RegistrationViewModel.tsx
+++ b/client/src/viewmodel/RegistrationViewModel.tsx
@@ -130,7 +130,7 @@ const RegistrationViewModel = () => {
       if ('error' in response) {
         console.error(response.error);
       } else {
-        dispatch({payload: response.success.toString(), type: 'resultMsg'});
+        dispatch({payload: response.data[0].toString(), type: 'resultMsg'});
         console.log(response); // Successfully registered
       }
     } catch (ex) {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@types/cookie-parser": "^1.4.6",
+        "@types/jsonwebtoken": "^9.0.5",
         "axios": "^1.6.7",
         "bcrypt": "^5.1.1",
         "cookie-parser": "^1.4.6",
@@ -18,6 +19,7 @@
         "express": "^4.18.2",
         "express-async-errors": "^3.1.1",
         "express-validator": "^7.0.1",
+        "jsonwebtoken": "^9.0.2",
         "nodemon": "^3.0.3",
         "pg": "^8.11.3",
         "pg-hstore": "^2.3.4",
@@ -582,6 +584,14 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
+    },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.5.tgz",
+      "integrity": "sha512-VRLSGzik+Unrup6BsouBeHsf4d1hOEgYWTm/7Nmw1sXoN1+tRly/Gy/po3yeahnP4jfnQWWAhQAqcNfH7ngOkA==",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/mime": {
       "version": "1.3.5",
@@ -1220,6 +1230,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+    },
     "node_modules/buffer-writer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
@@ -1653,6 +1668,14 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/dottie/-/dottie-2.0.6.tgz",
       "integrity": "sha512-iGCHkfUc5kFekGiqhe8B/mdaurD+lakO9txNnTvKtA6PISrw86LgqHvRzWYPyoE2Ph5aMIrCw9/uko6XHTKCwA=="
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -2941,6 +2964,51 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -2998,11 +3066,46 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -16,6 +16,7 @@
         "cors": "^2.8.5",
         "dotenv-safe": "^8.2.0",
         "express": "^4.18.2",
+        "express-async-errors": "^3.1.1",
         "express-validator": "^7.0.1",
         "nodemon": "^3.0.3",
         "pg": "^8.11.3",
@@ -2084,6 +2085,14 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/express-async-errors": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/express-async-errors/-/express-async-errors-3.1.1.tgz",
+      "integrity": "sha512-h6aK1da4tpqWSbyCa3FxB/V6Ehd4EEB15zyQq9qe75OZBp0krinNKuH4rAY+S/U/2I36vdLAUFSjQJ+TFmODng==",
+      "peerDependencies": {
+        "express": "^4.16.2"
       }
     },
     "node_modules/express-validator": {

--- a/server/package.json
+++ b/server/package.json
@@ -21,6 +21,7 @@
   "license": "ISC",
   "dependencies": {
     "@types/cookie-parser": "^1.4.6",
+    "@types/jsonwebtoken": "^9.0.5",
     "axios": "^1.6.7",
     "bcrypt": "^5.1.1",
     "cookie-parser": "^1.4.6",
@@ -29,6 +30,7 @@
     "express": "^4.18.2",
     "express-async-errors": "^3.1.1",
     "express-validator": "^7.0.1",
+    "jsonwebtoken": "^9.0.2",
     "nodemon": "^3.0.3",
     "pg": "^8.11.3",
     "pg-hstore": "^2.3.4",

--- a/server/package.json
+++ b/server/package.json
@@ -27,6 +27,7 @@
     "cors": "^2.8.5",
     "dotenv-safe": "^8.2.0",
     "express": "^4.18.2",
+    "express-async-errors": "^3.1.1",
     "express-validator": "^7.0.1",
     "nodemon": "^3.0.3",
     "pg": "^8.11.3",

--- a/server/src/api/api_manager.ts
+++ b/server/src/api/api_manager.ts
@@ -2,7 +2,7 @@ import {ResponseHandler} from './response_handler';
 import * as express from 'express';
 import {RootApi} from './root_api';
 import {UserApi} from './user_api';
-import {ErrorHandler} from './error_handler';
+import {ErrorHandler} from '../utilities/error_handler';
 import {ROOT_API_ROUTE} from '../utilities/configurations';
 import {USER_API_ROUTE} from '../utilities/configurations';
 import {NextFunction, Request, Response} from 'express';
@@ -65,7 +65,6 @@ class ApiManager {
       const entryRoute = express.Router();
       const entryInstance = new entry.class(
         this.responseHandler,
-        this.errorHandler,
         entryRoute
       );
       entryInstance.setupRequestHandling();

--- a/server/src/api/api_manager.ts
+++ b/server/src/api/api_manager.ts
@@ -63,10 +63,7 @@ class ApiManager {
     this.defineRoutes();
     this.apiList.forEach((entry: ApiRoute<any>) => {
       const entryRoute = express.Router();
-      const entryInstance = new entry.class(
-        this.responseHandler,
-        entryRoute
-      );
+      const entryInstance = new entry.class(this.responseHandler, entryRoute);
       entryInstance.setupRequestHandling();
       this.app.use(entry.route, entryRoute);
     });

--- a/server/src/api/response_handler.ts
+++ b/server/src/api/response_handler.ts
@@ -33,14 +33,27 @@ class ResponseHandler {
     response.status(httpStatusCode).json(apiResponse);
   }
 }
+
+/**
+ * This interface defines the shape of a success response to be sent back to the client, the data
+ * should be an array of any type.
+ */
 interface SuccessResponse<T> {
   success: true;
   data: T[];
 }
+
+/**
+ * This interface defines the shape of an error response to be sent back to the client.
+ */
 interface ErrorResponse {
   success: false;
   error: ErrorMessage;
 }
+
+/**
+ * This is a union type of the two different response types, to define a single type for the api response.
+ */
 type APIResponse<T> = SuccessResponse<T> | ErrorResponse;
 
 export {ResponseHandler};

--- a/server/src/api/response_handler.ts
+++ b/server/src/api/response_handler.ts
@@ -1,5 +1,5 @@
 import {Response} from 'express';
-import {ErrorMessage} from "../utilities/error_handler";
+import {ErrorMessage} from '../utilities/error_handler';
 
 /**
  * This class is a handler responsible for formatting and returning HTTP responses to the client.
@@ -20,15 +20,14 @@ class ResponseHandler {
     responseBody: any,
     error: boolean
   ) {
-
-    let apiResponse : APIResponse<any>;
-    if(error) {
-      apiResponse = {success:false, error:responseBody as ErrorMessage}
+    let apiResponse: APIResponse<any>;
+    if (error) {
+      apiResponse = {success: false, error: responseBody as ErrorMessage};
     } else {
       if (!Array.isArray(responseBody)) {
         responseBody = [responseBody];
       }
-      apiResponse = {success:true, data:responseBody as any[]}
+      apiResponse = {success: true, data: responseBody as any[]};
     }
     response.status(httpStatusCode).json(apiResponse);
   }

--- a/server/src/api/response_handler.ts
+++ b/server/src/api/response_handler.ts
@@ -1,4 +1,5 @@
 import {Response} from 'express';
+import {ErrorMessage} from "../utilities/error_handler";
 
 /**
  * This class is a handler responsible for formatting and returning HTTP responses to the client.
@@ -19,9 +20,27 @@ class ResponseHandler {
     responseBody: any,
     error: boolean
   ) {
-    const responseConclusion = error ? 'error' : 'success';
-    response.status(httpStatusCode).json({[responseConclusion]: responseBody});
+
+    let apiResponse : APIResponse<any>;
+    if(error) {
+      apiResponse = {success:false, error:responseBody as ErrorMessage}
+    } else {
+      if (!Array.isArray(responseBody)) {
+        responseBody = [responseBody];
+      }
+      apiResponse = {success:true, data:responseBody as any[]}
+    }
+    response.status(httpStatusCode).json(apiResponse);
   }
 }
+interface SuccessResponse<T> {
+  success: true;
+  data: T[];
+}
+interface ErrorResponse {
+  success: false;
+  error: ErrorMessage;
+}
+type APIResponse<T> = SuccessResponse<T> | ErrorResponse;
 
 export {ResponseHandler};

--- a/server/src/api/root_api.ts
+++ b/server/src/api/root_api.ts
@@ -20,19 +20,11 @@ class RootApi {
    * ,by the api manager.
    */
   async setupRequestHandling() {
-    this.router.get(
-      '/',
-        async (req: Request, res: Response) => {
-          const data = 'API is up and running!';
-          const httpStatusCode = 200;
-          this.responseHandler.sendHttpResponse(
-            res,
-            httpStatusCode,
-            data,
-            false
-          );
-        }
-    );
+    this.router.get('/', async (req: Request, res: Response) => {
+      const data = 'API is up and running!';
+      const httpStatusCode = 200;
+      this.responseHandler.sendHttpResponse(res, httpStatusCode, data, false);
+    });
   }
 }
 

--- a/server/src/api/root_api.ts
+++ b/server/src/api/root_api.ts
@@ -23,7 +23,7 @@ class RootApi {
     this.router.get(
       '/',
         async (req: Request, res: Response) => {
-          const data = {message: 'API is up and running!'};
+          const data = 'API is up and running!';
           const httpStatusCode = 200;
           this.responseHandler.sendHttpResponse(
             res,

--- a/server/src/api/root_api.ts
+++ b/server/src/api/root_api.ts
@@ -1,6 +1,5 @@
 import {Request, Response, Router} from 'express';
 import {ResponseHandler} from './response_handler';
-import {ErrorHandler} from './error_handler';
 
 /**
  * This class represents the default api route reached by not specifying a resource or action
@@ -9,12 +8,10 @@ class RootApi {
   /**
    * Dependencies needed for api operation are injected via this constructor.
    * @param responseHandler a handler used for formatting and sending HTTP responses.
-   * @param errorHandler a handler used for enabling error handling.
    * @param router the express route associated with this class.
    */
   constructor(
     private responseHandler: ResponseHandler,
-    private errorHandler: ErrorHandler,
     private router: Router
   ) {}
 
@@ -25,7 +22,6 @@ class RootApi {
   async setupRequestHandling() {
     this.router.get(
       '/',
-      this.errorHandler.asyncErrorWrapper(
         async (req: Request, res: Response) => {
           const data = {message: 'API is up and running!'};
           const httpStatusCode = 200;
@@ -36,7 +32,6 @@ class RootApi {
             false
           );
         }
-      )
     );
   }
 }

--- a/server/src/api/user_api.ts
+++ b/server/src/api/user_api.ts
@@ -57,7 +57,7 @@ class UserApi {
     this.router.get(
       '/',
         async (req: Request, res: Response) => {
-          const data = {message: 'user API is up!'};
+          const data= 'user API is up!';
           const httpStatusCode = 200;
           this.responseHandler.sendHttpResponse(
             res,

--- a/server/src/api/user_api.ts
+++ b/server/src/api/user_api.ts
@@ -3,7 +3,6 @@ import {baseSanitizationSchema} from '../utilities/validators';
 import {createUserService} from '../service/user_service_factory';
 import {UserRegistrationDTO} from '../model/dto/user_registration_dto';
 import {ValidationSanitizationError} from '../utilities/custom_errors';
-import {ErrorHandler} from './error_handler';
 import {ResponseHandler} from './response_handler';
 import {Request, Response, Router} from 'express';
 
@@ -14,12 +13,10 @@ class UserApi {
   /**
    * Dependencies needed for api operation are injected via this constructor.
    * @param responseHandler a handler used for formatting and sending HTTP responses.
-   * @param errorHandler a handler used for enabling error handling.
    * @param router the express route associated with this class.
    */
   constructor(
     private responseHandler: ResponseHandler,
-    private errorHandler: ErrorHandler,
     private router: Router
   ) {}
 
@@ -31,7 +28,6 @@ class UserApi {
     this.router.post(
       '/register',
       checkSchema(validationSchemaRegistrationPost),
-      this.errorHandler.asyncErrorWrapper(
         async (req: Request, res: Response) => {
           const errors = validationResult(req);
           if (!errors.isEmpty()) {
@@ -56,12 +52,10 @@ class UserApi {
           }
           return;
         }
-      )
-    );
+      );
 
     this.router.get(
       '/',
-      this.errorHandler.asyncErrorWrapper(
         async (req: Request, res: Response) => {
           const data = {message: 'user API is up!'};
           const httpStatusCode = 200;
@@ -73,7 +67,6 @@ class UserApi {
           );
           return;
         }
-      )
     );
   }
 

--- a/server/src/api/user_api.ts
+++ b/server/src/api/user_api.ts
@@ -28,46 +28,38 @@ class UserApi {
     this.router.post(
       '/register',
       checkSchema(validationSchemaRegistrationPost),
-        async (req: Request, res: Response) => {
-          const errors = validationResult(req);
-          if (!errors.isEmpty()) {
-            throw new ValidationSanitizationError(
-              errors
-                .array()
-                .map(err => err.msg)
-                .join(', ')
-            );
-          }
-          const userService = createUserService();
-          const registrationData = this.registrationDataPacker(req.body);
-          const state = await userService.handleRegistration(registrationData);
-          if (state) {
-            const data = 'Registration successful';
-            this.responseHandler.sendHttpResponse(res, 200, data, false);
-          } else {
-            console.log(
-              'handleRegistration did not return true without throwing an error'
-            );
-            throw new Error('server error');
-          }
-          return;
-        }
-      );
-
-    this.router.get(
-      '/',
-        async (req: Request, res: Response) => {
-          const data= 'user API is up!';
-          const httpStatusCode = 200;
-          this.responseHandler.sendHttpResponse(
-            res,
-            httpStatusCode,
-            data,
-            false
+      async (req: Request, res: Response) => {
+        const errors = validationResult(req);
+        if (!errors.isEmpty()) {
+          throw new ValidationSanitizationError(
+            errors
+              .array()
+              .map(err => err.msg)
+              .join(', ')
           );
-          return;
         }
+        const userService = createUserService();
+        const registrationData = this.registrationDataPacker(req.body);
+        const state = await userService.handleRegistration(registrationData);
+        if (state) {
+          const data = 'Registration successful';
+          this.responseHandler.sendHttpResponse(res, 200, data, false);
+        } else {
+          console.log(
+            'handleRegistration did not return true without throwing an error'
+          );
+          throw new Error('server error');
+        }
+        return;
+      }
     );
+
+    this.router.get('/', async (req: Request, res: Response) => {
+      const data = 'user API is up!';
+      const httpStatusCode = 200;
+      this.responseHandler.sendHttpResponse(res, httpStatusCode, data, false);
+      return;
+    });
   }
 
   /**

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -21,6 +21,9 @@ import {Database} from './integration/database';
 
 import {ApiManager} from './api/api_manager';
 
+require('express-async-errors');
+
+
 const SERVER_ROOT_DIR_PATH = path.join(__dirname, '..');
 
 dotenv.config({

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -23,7 +23,6 @@ import {ApiManager} from './api/api_manager';
 
 require('express-async-errors');
 
-
 const SERVER_ROOT_DIR_PATH = path.join(__dirname, '..');
 
 dotenv.config({
@@ -31,6 +30,14 @@ dotenv.config({
   example: path.join(SERVER_ROOT_DIR_PATH, '.env.example'),
 });
 
+const app = express();
+
+// final error fallback
+process.on('uncaughtException', err => {
+  console.error('Uncaught Exception:', err);
+  // eslint-disable-next-line
+  process.exit(1);
+});
 const db = Database.getInstance();
 try {
   db.connectToDatabase().then(() => {
@@ -43,7 +50,6 @@ try {
   console.log(error);
 }
 
-const app = express();
 app.use(express.json());
 app.use(express.urlencoded({extended: true}));
 app.use(cookieParser());

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -49,7 +49,7 @@ app.use(express.urlencoded({extended: true}));
 app.use(cookieParser());
 app.use(
   cors({
-    origin: 'http://localhost',
+    origin: '*',
     methods: ['GET', 'POST', 'PUT', 'DELETE'],
     credentials: true,
   })

--- a/server/src/utilities/error_handler.ts
+++ b/server/src/utilities/error_handler.ts
@@ -8,6 +8,7 @@ import {NextFunction, Request, Response} from 'express';
  */
 class ErrorHandler {
   constructor(private responseHandler: ResponseHandler) {}
+
   /**
    * This is a middleware to handle errors.
    *
@@ -21,25 +22,37 @@ class ErrorHandler {
    * @param req the express request
    * @param res the express response
    * @param next the next middleware to be called
+   * @todo Add full error logging here later.
    */
-
   // eslint-disable-next-line
   handleError(err: Error, req: Request, res: Response, next: NextFunction) {
     let httpStatusCode;
-    let message;
-    if (err instanceof ConflictError) {
-      httpStatusCode = 409;
-      message = 'That user already exists';
-    } else if (err instanceof ValidationSanitizationError) {
-      httpStatusCode = 400;
-      message = err.message;
-    } else {
-      httpStatusCode = 500;
-      message = "something went wrong on the server"
+    let errorMessage : ErrorMessage = {message: 'none'}
+
+    switch(err.constructor) {
+      case ConflictError:
+        httpStatusCode = 409;
+        errorMessage.message = 'That user already exists';
+        break;
+
+      case ValidationSanitizationError:
+        httpStatusCode = 400;
+        errorMessage.message = err.message
+        break;
+
+      default:
+        httpStatusCode = 500;
+        errorMessage.message = 'Something went wrong with the server'
+        break;
     }
-    this.responseHandler.sendHttpResponse(res, httpStatusCode, message, true);
+    this.responseHandler.sendHttpResponse(res, httpStatusCode, errorMessage, true);
     return;
   }
+}
+export interface ErrorMessage {
+  message: string,
+  code?: string,
+  details?: string
 }
 
 export {ErrorHandler};

--- a/server/src/utilities/error_handler.ts
+++ b/server/src/utilities/error_handler.ts
@@ -4,7 +4,13 @@ import {ResponseHandler} from '../api/response_handler';
 import {NextFunction, Request, Response} from 'express';
 
 /**
- * The purpose of this class is to facilitate error handling in the api layer.
+ * This class acts as a centralized error handler for the entire application.
+ * It does/shall:
+ * Log comprehensive error data,
+ * Standardize error responses,
+ * Decide what to do with the error: attempting recovery when appropriate/possible or
+ * composing informative error messages, masking sensitive or technical information.
+ *
  */
 class ErrorHandler {
   constructor(private responseHandler: ResponseHandler) {}
@@ -12,8 +18,8 @@ class ErrorHandler {
   /**
    * This is a middleware to handle errors.
    *
-   * It will receive an error, @param err, and set an appropriate code and message for the response,
-   * depending on the error type. Then it calls another handler to send the response.
+   * It will receive an error, @param err, set the appropriate http status code and then construct an errorMessage,
+   * to then be sent to response handler.
    *
    * eslint is disabled to not complain about unused req and next, which are mandatory in an express
    * error handling middleware.
@@ -49,6 +55,10 @@ class ErrorHandler {
     return;
   }
 }
+
+/**
+ * This interface defines a standard error message to be sent as a response to the client.
+ */
 export interface ErrorMessage {
   message: string,
   code?: string,

--- a/server/src/utilities/error_handler.ts
+++ b/server/src/utilities/error_handler.ts
@@ -1,6 +1,6 @@
-import {ConflictError} from '../utilities/custom_errors';
-import {ValidationSanitizationError} from '../utilities/custom_errors';
-import {ResponseHandler} from './response_handler';
+import {ConflictError} from './custom_errors';
+import {ValidationSanitizationError} from './custom_errors';
+import {ResponseHandler} from '../api/response_handler';
 import {NextFunction, Request, Response} from 'express';
 
 /**
@@ -8,24 +8,6 @@ import {NextFunction, Request, Response} from 'express';
  */
 class ErrorHandler {
   constructor(private responseHandler: ResponseHandler) {}
-
-  /**
-   * Used to wrap a route so that both async and sync errors will be handled by the next middleware
-   * (the next middleware should be an error handling middleware.)
-   * @param fn a function (route endpoint) to wrap
-   */
-  asyncErrorWrapper(
-    fn: (req: Request, res: Response, next: NextFunction) => Promise<void>
-  ) {
-    return async (req: Request, res: Response, next: NextFunction) => {
-      try {
-        await fn(req, res, next);
-      } catch (err) {
-        next(err);
-      }
-    };
-  }
-
   /**
    * This is a middleware to handle errors.
    *
@@ -53,6 +35,7 @@ class ErrorHandler {
       message = err.message;
     } else {
       httpStatusCode = 500;
+      message = "something went wrong on the server"
     }
     this.responseHandler.sendHttpResponse(res, httpStatusCode, message, true);
     return;


### PR DESCRIPTION
Refactored error handling on back end:

It now uses "express-async-errors"  package, this reduces boiler plate and automatically catches all errors that happens between request and response (though manual try catch is still possible).

Moved the centralized error handler to the utilities layer, added a few more handling cases and refactored to use switch statement for better readability.

Added a fallback error handling solution in the main file that will shut down the server if a uncaught error were to somehow reach it.

Also standardized API responses in the following ways:
{
    "success": false,
    "error": {
        "message": "Something went wrong with the server"
    }
}

{
    "success": true,
    "data": [
        {
            "thing1": 1
        },
        {
            "thing2": 2
        },
    ]
}